### PR TITLE
Fixing Gen 3 UUBL

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3115,8 +3115,8 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 		ruleset: ['[Gen 3] OU', '!One Boost Passer Clause'],
 		banlist: [
 			'OU', 'Smeargle + Ingrain', 'Baton Pass + Block', 'Baton Pass + Mean Look', 'Baton Pass + Spider Web', 'Flail', 'Reversal',
-			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance',
-		],
+			'Baton Pass + Speed Boost', 'Baton Pass + Agility', 'Baton Pass + Dragon Dance', 'Baton Pass + Salac Berry'],
+		unbanlist: ['Soundproof', 'Sand Veil'],
 	},
 
 	// Past Gens OU


### PR DESCRIPTION
- Added 'Baton Pass + Salac Berry" to banlist which was always intended to be included, but was missed initially.
- Unbanned Soundproof and Sand Veil, which are bans carried over from OU that should not apply